### PR TITLE
Change requiring Android SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To start a new Android project:
 
 2. Set your `ANDROID_HOME` environment variable to `/usr/local/opt/android-sdk`.
 
-3. Run the Android SDK GUI and install API 18 and any other APIs you might need. You can start the GUI by invoking `android`
+3. Run the Android SDK GUI and install API 19 and any other APIs you might need. You can start the GUI by invoking `android`
 
 4. Download Deckard from GitHub:
     ```bash


### PR DESCRIPTION
First I read README.md.
Next I installed Android SDK 18 and ran 

```bash
./gradlew clean test
```
 But it was failure.
Because compileSdkVersion is Android 19.

Considering travis test are using AndroidSDK19,I want to modify README.md.
Could you check my pull request?