### PR TITLE
Remove sdk versions from manifest

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -4,9 +4,6 @@
           android:versionName="1.0.0-SNAPSHOT"
           package="com.example">
 
-    <uses-sdk android:minSdkVersion="18"
-              android:targetSdkVersion="18"/>
-
     <application android:name=".DeckardApplication">
         <activity android:name=".activity.DeckardActivity" android:screenOrientation="portrait">
             <intent-filter>


### PR DESCRIPTION
SDK versions are managed by `build.gradle` now.