### PR TITLE
Changes needed for Android Studio 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ To start a new Android project:
 
 1. Install [Android Studio](http://developer.android.com/sdk/index.html).
 
-2. Run the [Android SDK Manager](http://developer.android.com/tools/help/sdk-manager.html) and install `API 19` and `Build-tools 21.1.2`.
+2. Run the [Android SDK Manager](http://developer.android.com/tools/help/sdk-manager.html) and install
+`API 19` and `Build-tools 21.1.2`.
 
 3. Download Deckard from GitHub:
     ```bash
@@ -44,13 +45,18 @@ To start a new Android project:
 ## Android Studio Support
 
 ### Compatibility
-Use the latest Android Studio. The most recent updates were run against Android Studio 1.0.1 with the 'Android Studio Unit Test' plugin available from 'Browse Repositories...'.
+Use the latest Android Studio. The most recent updates were run against Android Studio 1.1.0 with
+"Unit Testing support" enabled in Studio's Gradle settings.
 
 ### Importing
 Import the project into Android Studio by selecting 'Import Project' and selecting the project's `build.gradle`. When prompted, you can just pick the default gradle wrapper.
 
 ### Running the Robolectric Test
-You should now be able to `DeckardActivityRobolectricTest`. Run it as a normal JUnit test - make sure to choose the JUnit test runner and not the Android one.
+To run Robolectric tests (example can be found in DeckardActivityTest) open Studio's
+"Build Variants" pane and change the "Test Artifact" to "Unit Tests". You can then run
+Robolectric tests using the JUnit test runner.
 
 ### Running the Espresso Test
-The Espresso tests are runnable with the Android test runner within Android Studio.
+To run Robolectric tests (example can be found in DeckardEspressoTest) open Studio's
+"Build Variants" pane and change the "Test Artifact" to "Android Instrumentation Tests".
+You can then run Espresso tests using the Android test runner.

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.0'
         classpath 'com.github.jcandksolutions.gradle:android-unit-test:2.1.1'
     }
 }
@@ -34,8 +34,6 @@ android {
         exclude 'LICENSE.txt'
     }
 }
-
-apply plugin: 'android-unit-test'
 
 dependencies {
     repositories {

--- a/src/test/java/com/example/activity/DeckardActivityTest.java
+++ b/src/test/java/com/example/activity/DeckardActivityTest.java
@@ -4,10 +4,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", emulateSdk = 18)
 public class DeckardActivityTest {
 
     @Test


### PR DESCRIPTION
These are the initial changes required to make Deckard work with Android Studio 1.1.0. Basically the new unit testing functionality adds the ability to run Robolectric tests without the need for a gradle plugin. There were a couple of issues I've highlighted in the changes.

We'll need to hold off on merging this until 1.1.0 is actually released which should hopefully be soon. The readme also needs updated.

One weird thing is that Studio now needs to switch build variants when running either Robolectric or Espresso (Android instrumentation for Espresso and Unit testing for Robolectric). This basically switches between either src/androidTest or src/test being on the classpath. Testing in gradle is all normal however.