### PR TITLE
Upgrade android gradle plugin to 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.1.3'
     }
 }
 


### PR DESCRIPTION
This version of the android gradle plugin is much better behaved. Works with AndroidStudio 1.2 (currently in beta).