### PR TITLE
Updates Espresso tests to ActivityTestRule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,11 @@ allprojects {
 }
 
 dependencies {
+
     repositories {
-        mavenCentral()
+        jcenter()
+
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     compile 'com.android.support:support-v4:22.1.0'
@@ -51,23 +54,5 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-core:1.1'
     testCompile 'org.hamcrest:hamcrest-library:1.1'
     testCompile 'org.hamcrest:hamcrest-integration:1.1'
-
-    // TODO: requires special build of robolectric right now. working on this...
-    testCompile('org.robolectric:robolectric:2.4') {
-        exclude module: 'classworlds'
-        exclude module: 'commons-logging'
-        exclude module: 'httpclient'
-        exclude module: 'maven-artifact'
-        exclude module: 'maven-artifact-manager'
-        exclude module: 'maven-error-diagnostics'
-        exclude module: 'maven-model'
-        exclude module: 'maven-project'
-        exclude module: 'maven-settings'
-        exclude module: 'plexus-container-default'
-        exclude module: 'plexus-interpolation'
-        exclude module: 'plexus-utils'
-        exclude module: 'wagon-file'
-        exclude module: 'wagon-http-lightweight'
-        exclude module: 'wagon-provider-api'
-    }
+    testCompile "org.robolectric:robolectric:3.0-SNAPSHOT"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 
@@ -28,6 +28,12 @@ android {
     }
 }
 
+allprojects {
+    configurations.all {
+        resolutionStrategy.force 'com.android.support:support-annotations:22.1.0'
+    }
+}
+
 dependencies {
     repositories {
         mavenCentral()
@@ -36,8 +42,9 @@ dependencies {
     compile 'com.android.support:support-v4:22.1.0'
 
     // Espresso
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.0')
-    androidTestCompile('com.android.support.test:testing-support-lib:0.1')
+    androidTestCompile 'com.android.support.test:runner:0.2'
+    androidTestCompile 'com.android.support.test:rules:0.2'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.1'
 
     // Robolectric
     testCompile 'junit:junit:4.12'

--- a/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
+++ b/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
@@ -17,7 +17,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 public class DeckardEspressoTest {
 
     @Rule
-    public ActivityTestRule<DeckardActivity> mActivityRule = new ActivityTestRule<>(DeckardActivity.class);
+    public ActivityTestRule<DeckardActivity> mActivityRule = new ActivityTestRule<DeckardActivity>(DeckardActivity.class);
 
 
     @Test

--- a/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
+++ b/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
@@ -1,26 +1,26 @@
 package com.example.activity;
 
-import com.example.R;
-import android.test.ActivityInstrumentationTestCase2;
+import android.support.test.rule.ActivityTestRule;
 import android.test.suitebuilder.annotation.LargeTest;
+
+import com.example.R;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 @LargeTest
-public class DeckardEspressoTest extends ActivityInstrumentationTestCase2<DeckardActivity> {
+public class DeckardEspressoTest {
 
-    public DeckardEspressoTest() {
-        super(DeckardActivity.class);
-    }
+    @Rule
+    public ActivityTestRule<DeckardActivity> mActivityRule = new ActivityTestRule<>(DeckardActivity.class);
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        getActivity();
-    }
 
+    @Test
     public void testActivityShouldHaveText() throws InterruptedException {
         onView(withId(R.id.text)).check(matches(withText("Hello Espresso!")));
     }

--- a/src/test/java/com/example/activity/DeckardActivityTest.java
+++ b/src/test/java/com/example/activity/DeckardActivityTest.java
@@ -1,5 +1,7 @@
 package com.example.activity;
 
+import com.example.BuildConfig;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -9,7 +11,7 @@ import org.robolectric.annotation.Config;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", emulateSdk = 18)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = "src/main/AndroidManifest.xml")
 public class DeckardActivityTest {
 
     @Test


### PR DESCRIPTION
Replaces the usage of the deprecated ActivityInstrumentationTestCase2