### PR TITLE
Updates Espresso tests to ActivityTestRule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,9 @@ dependencies {
 
     // Espresso
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
-    
+    androidTestCompile 'com.android.support.test:runner:0.3'
+    androidTestCompile 'com.android.support.test:rules:0.3'
+
     // Robolectric
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
+++ b/src/androidTest/java/com/example/activity/DeckardEspressoTest.java
@@ -1,26 +1,28 @@
 package com.example.activity;
 
 import com.example.R;
+
+import android.support.test.rule.ActivityTestRule;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.suitebuilder.annotation.LargeTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 @LargeTest
-public class DeckardEspressoTest extends ActivityInstrumentationTestCase2<DeckardActivity> {
+public class DeckardEspressoTest  {
 
-    public DeckardEspressoTest() {
-        super(DeckardActivity.class);
-    }
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        getActivity();
-    }
+    @Rule
+    public ActivityTestRule<DeckardActivity> mActivityRule =
+            new ActivityTestRule<>(DeckardActivity.class);
 
+    @Test
     public void testActivityShouldHaveText() throws InterruptedException {
         onView(withId(R.id.text)).check(matches(withText("Hello Espresso!")));
     }


### PR DESCRIPTION
Replaces the usage of the deprecated ActivityInstrumentationTestCase2